### PR TITLE
It is much better for the PRNG to be instantiated only once.

### DIFF
--- a/src/com/jlmd/simpleneuralnetwork/neuralnetwork/utils/Utils.java
+++ b/src/com/jlmd/simpleneuralnetwork/neuralnetwork/utils/Utils.java
@@ -6,6 +6,10 @@ import java.util.Random;
  * @author jlmd
  */
 public class Utils {
+
+    /** Pseudo-random number generator instance. */
+    private static final Random rand = new Random();
+
     /**
      * Returns a pseudo-random number between min and max, inclusive
      * @param min Minimum value
@@ -13,7 +17,6 @@ public class Utils {
      * @return float between min and max, inclusive
      */
     public static float randFloat(float min, float max) {
-        Random rand = new Random();
         return rand.nextFloat() * (max - min) + min;
     }
 }


### PR DESCRIPTION
Otherwise too many objects are repeatedly generated and the garbage collector is constantly involved in memory release. 